### PR TITLE
Check layer when user views map

### DIFF
--- a/wm_extra/views.py
+++ b/wm_extra/views.py
@@ -419,7 +419,7 @@ def geoexplorer2worldmap(config, map_obj, layers=None):
             # detect if it is a WM layer
             if layer_config['local'] == True:
                 # WM local layer to process
-                if 'styles' not in layer_config:
+                if 'styles' not in layer_config and Layer.objects.filter(typename=layer_config['name']).exists():
                     layer = Layer.objects.get(typename=layer_config['name'])
                     layer_config['styles'] = [style.name for style in layer.styles.all()]
             else:


### PR DESCRIPTION
When the user wants to view a map..some layers do not exist within the layers_layer table. Also, some MapLayers objects has wrong name, which corresponds to incorrect layer typename. This pull request enables worldmap to check which layers before retreiving information from each layer